### PR TITLE
fix(utils): use passed status name in error method in response builder

### DIFF
--- a/src/main/java/com/_200studios/learn/shared/utils/api/ResponseBuilder.java
+++ b/src/main/java/com/_200studios/learn/shared/utils/api/ResponseBuilder.java
@@ -10,6 +10,6 @@ public class ResponseBuilder {
 
     public static <T> ResponseEntity<ApiResponse<T>> error(String message, HttpStatus status) {
         return ResponseEntity.status(status)
-                .body(new ApiResponse<>(HttpStatus.OK.name(), null, message));
+                .body(new ApiResponse<>(status.name(), null, message));
     }
 }


### PR DESCRIPTION
Previously, the "OK" status was being used